### PR TITLE
Update README.md for OnlyTutors project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![CI Status](https://github.com/AY2526S2-CS2103T-T17-3/tp/workflows/Java%20CI/badge.svg)](https://github.com/AY2526S2-CS2103T-T17-3/tp/actions)
-[![codecov](https://codecov.io/gh/AY2526S2-CS2103T-W11-2/tp/graph/badge.svg?token=Y8F23W06X3)](https://codecov.io/gh/AY2526S2-CS2103T-W11-2/tp)
+[![codecov](https://codecov.io/gh/AY2526S2-CS2103T-T17-3/tp/graph/badge.svg?token=Y8F23W06X3)](https://codecov.io/gh/AY2526S2-CS2103T-T17-3/tp)
 
 ![Ui](docs/images/Ui.png)
 


### PR DESCRIPTION
Update CI badge to point to team repo, replace AB3 boilerplate with OnlyTutors product description, and add SE-EDU acknowledgement.