### PR TITLE
[DO NOT APPROVE YET] Update ClearConfirmation

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 
 /**
@@ -9,14 +10,60 @@ import seedu.address.model.Model;
  */
 public class ClearCommand extends Command {
 
-    public static final String COMMAND_WORD = "clear";
-    public static final String MESSAGE_CONFIRM = "This will delete all contacts. "
-            + "Type 'confirm clear' if you would still like to proceed.";
+    /**
+     * Represents the confirmation state of a {@code ClearCommand}.
+     * <ul>
+     *     <li>{@code PROMPT} - The user has typed {@code clear} and is awaiting confirmation.</li>
+     *     <li>{@code CONFIRMED} - The user confirmed with {@code y}, address book will be cleared.</li>
+     *     <li>{@code ABORTED} - The user aborted with {@code n}, no changes will be made.</li>
+     * </ul>
+     */
+    public enum ClearState {
+        PROMPT, CONFIRMED, ABORTED
+    }
 
+    public static final String COMMAND_WORD = "clear";
+    public static final String MESSAGE_CONFIRM_PROMPT =
+            "This will delete all contacts. Are you sure? [y/N]:";
+    public static final String MESSAGE_ABORTED = "Clear aborted.";
+    public static final String MESSAGE_SUCCESS = "Cleared all contacts";
+
+    private final ClearState state;
+
+    public ClearCommand(ClearState state) {
+        this.state = state;
+    }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        return new CommandResult(MESSAGE_CONFIRM);
+        switch (state) {
+        case PROMPT:
+            return new CommandResult(MESSAGE_CONFIRM_PROMPT);
+        case ABORTED:
+            return new CommandResult(MESSAGE_ABORTED);
+        case CONFIRMED:
+            model.setAddressBook(new AddressBook());
+            return new CommandResult(MESSAGE_SUCCESS);
+        default:
+            throw new AssertionError("Unknown ClearState: " + state);
+        }
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if (!(other instanceof ClearCommand)) {
+            return false;
+        }
+        ClearCommand otherClearCommand = (ClearCommand) other;
+        return state == otherClearCommand.state;
+    }
+
+    @Override
+    public int hashCode() {
+        return state.hashCode();
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -11,7 +11,6 @@ import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
-import seedu.address.logic.commands.ConfirmCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
@@ -33,6 +32,7 @@ public class AddressBookParser {
      */
     private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+)(?<arguments>.*)");
     private static final Logger logger = LogsCenter.getLogger(AddressBookParser.class);
+    private boolean awaitingClearConfirmation = false;
 
     /**
      * Parses user input into command for execution.
@@ -42,6 +42,17 @@ public class AddressBookParser {
      * @throws ParseException if the user input does not conform the expected format
      */
     public Command parseCommand(String userInput) throws ParseException {
+        if (awaitingClearConfirmation) {
+            awaitingClearConfirmation = false;
+            String input = userInput.trim();
+            if (input.equalsIgnoreCase("y")) {
+                return new ClearCommand(ClearCommand.ClearState.CONFIRMED);
+            } else if (input.equalsIgnoreCase("n")) {
+                return new ClearCommand(ClearCommand.ClearState.ABORTED);
+            }
+            throw new ParseException("Invalid input. Type 'y' to confirm or 'n' to abort.");
+        }
+
         final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
         if (!matcher.matches()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
@@ -67,10 +78,8 @@ public class AddressBookParser {
             return new DeleteCommandParser().parse(arguments);
 
         case ClearCommand.COMMAND_WORD:
-            return new ClearCommand();
-
-        case ConfirmCommand.COMMAND_WORD:
-            return new ConfirmCommandParser().parse(arguments);
+            awaitingClearConfirmation = true;
+            return new ClearCommand(ClearCommand.ClearState.PROMPT);
 
         case FindCommand.COMMAND_WORD:
             return new FindCommandParser().parse(arguments);

--- a/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
@@ -12,18 +12,30 @@ import seedu.address.model.UserPrefs;
 public class ClearCommandTest {
 
     @Test
-    public void execute_emptyAddressBook_success() {
+    public void execute_prompt_showsConfirmMessage() {
         Model model = new ModelManager();
         Model expectedModel = new ModelManager();
 
-        assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_CONFIRM, expectedModel);
+        assertCommandSuccess(new ClearCommand(ClearCommand.ClearState.PROMPT),
+                model, ClearCommand.MESSAGE_CONFIRM_PROMPT, expectedModel);
     }
 
     @Test
-    public void execute_nonEmptyAddressBook_success() {
+    public void execute_aborted_showsAbortMessage() {
         Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
         Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
-        assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_CONFIRM, expectedModel);
+        // Model should be unchanged after abort
+        assertCommandSuccess(new ClearCommand(ClearCommand.ClearState.ABORTED),
+                model, ClearCommand.MESSAGE_ABORTED, expectedModel);
+    }
+
+    @Test
+    public void execute_confirmed_emptyAddressBook() {
+        Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        Model expectedModel = new ModelManager();
+
+        assertCommandSuccess(new ClearCommand(ClearCommand.ClearState.CONFIRMED),
+                model, ClearCommand.MESSAGE_SUCCESS, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -167,7 +167,7 @@ public class EditCommandTest {
         assertFalse(standardCommand.equals(null));
 
         // different types -> returns false
-        assertFalse(standardCommand.equals(new ClearCommand()));
+        assertFalse(standardCommand.equals(new ClearCommand(ClearCommand.ClearState.PROMPT)));
 
         // different index -> returns false
         assertFalse(standardCommand.equals(new EditCommand(INDEX_SECOND_PERSON, DESC_AMY)));

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.Test;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.AddTagCommand;
 import seedu.address.logic.commands.ClearCommand;
-import seedu.address.logic.commands.ConfirmCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.DeleteTagCommand;
 import seedu.address.logic.commands.EditCommand;
@@ -47,21 +46,50 @@ public class AddressBookParserTest {
     }
 
     @Test
-    public void parseCommand_clear() throws Exception {
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD) instanceof ClearCommand);
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " 3") instanceof ClearCommand);
+    public void parseCommand_clear_returnsPrompt() throws Exception {
+        ClearCommand command = (ClearCommand) parser.parseCommand(ClearCommand.COMMAND_WORD);
+        assertEquals(new ClearCommand(ClearCommand.ClearState.PROMPT), command);
     }
 
     @Test
-    public void parseCommand_confirm() throws Exception {
-        ConfirmCommand command = (ConfirmCommand) parser.parseCommand("confirm clear");
-        assertEquals(new ConfirmCommand("clear"), command);
+    public void parseCommand_clearThenY_returnsConfirmed() throws Exception {
+        parser.parseCommand(ClearCommand.COMMAND_WORD);
+        ClearCommand command = (ClearCommand) parser.parseCommand("y");
+        assertEquals(new ClearCommand(ClearCommand.ClearState.CONFIRMED), command);
     }
 
     @Test
-    public void parseCommand_confirmEmpty() throws Exception {
-        ConfirmCommand command = (ConfirmCommand) parser.parseCommand("confirm ");
-        assertEquals(new ConfirmCommand(""), command);
+    public void parseCommand_clearThenUpperY_returnsConfirmed() throws Exception {
+        parser.parseCommand(ClearCommand.COMMAND_WORD);
+        ClearCommand command = (ClearCommand) parser.parseCommand("Y");
+        assertEquals(new ClearCommand(ClearCommand.ClearState.CONFIRMED), command);
+    }
+
+    @Test
+    public void parseCommand_clearThenN_returnsAborted() throws Exception {
+        parser.parseCommand(ClearCommand.COMMAND_WORD);
+        ClearCommand command = (ClearCommand) parser.parseCommand("n");
+        assertEquals(new ClearCommand(ClearCommand.ClearState.ABORTED), command);
+    }
+
+    @Test
+    public void parseCommand_clearThenUpperN_returnsAborted() throws Exception {
+        parser.parseCommand(ClearCommand.COMMAND_WORD);
+        ClearCommand command = (ClearCommand) parser.parseCommand("N");
+        assertEquals(new ClearCommand(ClearCommand.ClearState.ABORTED), command);
+    }
+
+    @Test
+    public void parseCommand_clearThenInvalidInput_throwsParseException() throws Exception {
+        parser.parseCommand(ClearCommand.COMMAND_WORD);
+        assertThrows(ParseException.class, () -> parser.parseCommand("maybe"));
+    }
+
+    @Test
+    public void parseCommand_clearConfirmWithoutClear_throwsParseException() {
+        // bypass attempt — should fail as unknown command
+        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () ->
+                parser.parseCommand("confirm clear"));
     }
 
     @Test
@@ -70,6 +98,7 @@ public class AddressBookParserTest {
                 DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
         assertEquals(new DeleteCommand(INDEX_FIRST_PERSON), command);
     }
+
 
     @Test
     public void parseCommand_edit() throws Exception {


### PR DESCRIPTION
Updated confirm clear logic prompting user to key in y/n (case-insenstive) to confirm or abort.