### PR TITLE
Fix mark/unmark error message grammar and add student names

### DIFF
--- a/src/main/java/seedu/address/logic/commands/MarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkCommand.java
@@ -29,7 +29,9 @@ public class MarkCommand extends Command {
 
     public static final String MESSAGE_MARK_PERSON_SUCCESS = "Marked student as paid: %1$s";
     public static final String MESSAGE_MARK_PERSONS_SUCCESS = "Marked %1$d students as paid: %2$s";
-    public static final String MESSAGE_ALREADY_PAID = "This student has already been marked as paid.";
+    public static final String MESSAGE_ALREADY_PAID = "This student has already been marked as paid: %1$s";
+    public static final String MESSAGE_ALREADY_PAID_PLURAL =
+            "These students have already been marked as paid: %1$s";
 
     private final List<Index> targetIndices;
 
@@ -53,12 +55,21 @@ public class MarkCommand extends Command {
         }
 
         List<Person> personsToMark = new ArrayList<>();
+        List<String> alreadyPaidNames = new ArrayList<>();
         for (Index index : targetIndices) {
             Person person = lastShownList.get(index.getZeroBased());
             if (person.isPaid()) {
-                throw new CommandException(MESSAGE_ALREADY_PAID);
+                alreadyPaidNames.add("(" + (index.getOneBased()) + ") " + person.getName());
+            } else {
+                personsToMark.add(person);
             }
-            personsToMark.add(person);
+        }
+        if (!alreadyPaidNames.isEmpty()) {
+            String names = String.join(", ", alreadyPaidNames);
+            String message = alreadyPaidNames.size() == 1
+                    ? String.format(MESSAGE_ALREADY_PAID, names)
+                    : String.format(MESSAGE_ALREADY_PAID_PLURAL, names);
+            throw new CommandException(message);
         }
 
         List<Person> markedPersons = new ArrayList<>();

--- a/src/main/java/seedu/address/logic/commands/UnmarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnmarkCommand.java
@@ -29,7 +29,9 @@ public class UnmarkCommand extends Command {
 
     public static final String MESSAGE_UNMARK_PERSON_SUCCESS = "Marked student as unpaid: %1$s";
     public static final String MESSAGE_UNMARK_PERSONS_SUCCESS = "Marked %1$d students as unpaid: %2$s";
-    public static final String MESSAGE_ALREADY_UNPAID = "This student has already been marked as unpaid.";
+    public static final String MESSAGE_ALREADY_UNPAID = "This student has already been marked as unpaid: %1$s";
+    public static final String MESSAGE_ALREADY_UNPAID_PLURAL =
+            "These students have already been marked as unpaid: %1$s";
 
     private final List<Index> targetIndices;
 
@@ -53,12 +55,21 @@ public class UnmarkCommand extends Command {
         }
 
         List<Person> personsToUnmark = new ArrayList<>();
+        List<String> alreadyUnpaidNames = new ArrayList<>();
         for (Index index : targetIndices) {
             Person person = lastShownList.get(index.getZeroBased());
             if (!person.isPaid()) {
-                throw new CommandException(MESSAGE_ALREADY_UNPAID);
+                alreadyUnpaidNames.add("(" + (index.getOneBased()) + ") " + person.getName());
+            } else {
+                personsToUnmark.add(person);
             }
-            personsToUnmark.add(person);
+        }
+        if (!alreadyUnpaidNames.isEmpty()) {
+            String names = String.join(", ", alreadyUnpaidNames);
+            String message = alreadyUnpaidNames.size() == 1
+                    ? String.format(MESSAGE_ALREADY_UNPAID, names)
+                    : String.format(MESSAGE_ALREADY_UNPAID_PLURAL, names);
+            throw new CommandException(message);
         }
 
         List<Person> unmarkedPersons = new ArrayList<>();

--- a/src/test/java/seedu/address/logic/commands/MarkCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/MarkCommandTest.java
@@ -90,7 +90,9 @@ public class MarkCommandTest {
 
         MarkCommand markCommand = new MarkCommand(List.of(INDEX_FIRST_PERSON));
 
-        assertCommandFailure(markCommand, model, MarkCommand.MESSAGE_ALREADY_PAID);
+        String expectedMessage = String.format(MarkCommand.MESSAGE_ALREADY_PAID,
+                "(" + INDEX_FIRST_PERSON.getOneBased() + ") " + alreadyPaidPerson.getName());
+        assertCommandFailure(markCommand, model, expectedMessage);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/UnmarkCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnmarkCommandTest.java
@@ -94,9 +94,12 @@ public class UnmarkCommandTest {
     @Test
     public void execute_alreadyUnpaid_throwsCommandException() {
         // Typical persons default to isPaid = false
+        Person person = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         UnmarkCommand unmarkCommand = new UnmarkCommand(List.of(INDEX_FIRST_PERSON));
 
-        assertCommandFailure(unmarkCommand, model, UnmarkCommand.MESSAGE_ALREADY_UNPAID);
+        String expectedMessage = String.format(UnmarkCommand.MESSAGE_ALREADY_UNPAID,
+                "(" + INDEX_FIRST_PERSON.getOneBased() + ") " + person.getName());
+        assertCommandFailure(unmarkCommand, model, expectedMessage);
     }
 
     @Test


### PR DESCRIPTION
Show which students are already marked/unmarked with their index and name. Use plural form when multiple students are affected.

Closes #170