### PR TITLE
Fix duplicate indices in delete/mark/unmark commands

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -51,7 +51,7 @@ public class DeleteCommand extends Command {
         }
 
         List<Person> personsToDelete = new ArrayList<>();
-        for (Index index : targetIndices) {
+        for (Index index : targetIndices.stream().distinct().collect(java.util.stream.Collectors.toList())) {
             personsToDelete.add(lastShownList.get(index.getZeroBased()));
         }
 

--- a/src/main/java/seedu/address/logic/commands/MarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkCommand.java
@@ -56,7 +56,7 @@ public class MarkCommand extends Command {
 
         List<Person> personsToMark = new ArrayList<>();
         List<String> alreadyPaidNames = new ArrayList<>();
-        for (Index index : targetIndices) {
+        for (Index index : targetIndices.stream().distinct().collect(java.util.stream.Collectors.toList())) {
             Person person = lastShownList.get(index.getZeroBased());
             if (person.isPaid()) {
                 alreadyPaidNames.add("(" + (index.getOneBased()) + ") " + person.getName());

--- a/src/main/java/seedu/address/logic/commands/UnmarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnmarkCommand.java
@@ -56,7 +56,7 @@ public class UnmarkCommand extends Command {
 
         List<Person> personsToUnmark = new ArrayList<>();
         List<String> alreadyUnpaidNames = new ArrayList<>();
-        for (Index index : targetIndices) {
+        for (Index index : targetIndices.stream().distinct().collect(java.util.stream.Collectors.toList())) {
             Person person = lastShownList.get(index.getZeroBased());
             if (!person.isPaid()) {
                 alreadyUnpaidNames.add("(" + (index.getOneBased()) + ") " + person.getName());

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -98,6 +98,20 @@ public class DeleteCommandTest {
     }
 
     @Test
+    public void execute_duplicateIndices_deletesPersonOnce() {
+        Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        DeleteCommand deleteCommand = new DeleteCommand(List.of(INDEX_FIRST_PERSON, INDEX_FIRST_PERSON));
+
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
+                Messages.format(personToDelete));
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deletePerson(personToDelete);
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
     public void equals() {
         DeleteCommand deleteFirstCommand = new DeleteCommand(List.of(INDEX_FIRST_PERSON));
         DeleteCommand deleteSecondCommand = new DeleteCommand(List.of(INDEX_SECOND_PERSON));

--- a/src/test/java/seedu/address/logic/commands/MarkCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/MarkCommandTest.java
@@ -115,6 +115,21 @@ public class MarkCommandTest {
     }
 
     @Test
+    public void execute_duplicateIndices_marksPersonOnce() {
+        Person personToMark = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        MarkCommand markCommand = new MarkCommand(List.of(INDEX_FIRST_PERSON, INDEX_FIRST_PERSON));
+
+        Person markedPerson = new PersonBuilder(personToMark).withPaid(true).build();
+        String expectedMessage = String.format(MarkCommand.MESSAGE_MARK_PERSON_SUCCESS,
+                Messages.format(markedPerson));
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.setPerson(personToMark, markedPerson);
+
+        assertCommandSuccess(markCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
     public void equals() {
         MarkCommand markFirstCommand = new MarkCommand(List.of(INDEX_FIRST_PERSON));
         MarkCommand markSecondCommand = new MarkCommand(List.of(INDEX_SECOND_PERSON));

--- a/src/test/java/seedu/address/logic/commands/UnmarkCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnmarkCommandTest.java
@@ -127,6 +127,24 @@ public class UnmarkCommandTest {
     }
 
     @Test
+    public void execute_duplicateIndices_unmarksPersonOnce() {
+        Person personToUnmark = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person paidPerson = new PersonBuilder(personToUnmark).withPaid(true).build();
+        model.setPerson(personToUnmark, paidPerson);
+
+        UnmarkCommand unmarkCommand = new UnmarkCommand(List.of(INDEX_FIRST_PERSON, INDEX_FIRST_PERSON));
+
+        Person unmarkedPerson = new PersonBuilder(paidPerson).withPaid(false).build();
+        String expectedMessage = String.format(UnmarkCommand.MESSAGE_UNMARK_PERSON_SUCCESS,
+                Messages.format(unmarkedPerson));
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.setPerson(paidPerson, unmarkedPerson);
+
+        assertCommandSuccess(unmarkCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
     public void equals() {
         UnmarkCommand unmarkFirstCommand = new UnmarkCommand(List.of(INDEX_FIRST_PERSON));
         UnmarkCommand unmarkSecondCommand = new UnmarkCommand(List.of(INDEX_SECOND_PERSON));


### PR DESCRIPTION
Deduplicate target indices before processing in DeleteCommand, MarkCommand, and UnmarkCommand to prevent PersonNotFoundException when the same index is provided more than once.

Closes #199, #169