### PR TITLE
Fix tag find to support partial keyword matching

### DIFF
--- a/src/main/java/seedu/address/model/person/TagsContainKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/TagsContainKeywordsPredicate.java
@@ -20,7 +20,7 @@ public class TagsContainKeywordsPredicate implements Predicate<Person> {
     public boolean test(Person person) {
         for (String keyword : keywords) {
             if (person.getTags().stream()
-                    .noneMatch(tag -> tag.tagName.equalsIgnoreCase(keyword))) {
+                    .noneMatch(tag -> tag.tagName.toLowerCase().contains(keyword.toLowerCase()))) {
                 return false;
             }
         }

--- a/src/test/java/seedu/address/model/person/TagsContainKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/TagsContainKeywordsPredicateTest.java
@@ -36,6 +36,15 @@ class TagsContainKeywordsPredicateTest {
     }
 
     @Test
+    void test_singleKeywordPartialMatch() {
+        // "math" should match tag "mathematics"
+        TagsContainKeywordsPredicate predicate =
+            new TagsContainKeywordsPredicate(Collections.singletonList("math"));
+        Person person = new PersonBuilder().withTags("mathematics").build();
+        assertTrue(predicate.test(person));
+    }
+
+    @Test
     void test_multipleKeywordsPartialMatch() {
         TagsContainKeywordsPredicate predicate =
             new TagsContainKeywordsPredicate(Arrays.asList("friends", "colleagues"));


### PR DESCRIPTION
Change tag find from exact match to substring match so that searching for 'math' also returns tags like 'mathematics'.

Closes #158