### PR TITLE
Fix documentation bugs from PE-D

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -375,11 +375,6 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
     Use case ends.
 
-* 1b. OnlyTutors detects a missing or invalid tag
-  * 1b1. OnlyTutors informs the tutor of the error.
-
-    Use case ends.
-
 * 2a. OnlyTutors detects that none of the specified tags exist on the student
   * 2a1. OnlyTutors informs the tutor that no changes were made.
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -83,7 +83,7 @@ The **API** of this component is specified in [`Ui.java`](https://github.com/se-
 
 The UI consists of a `MainWindow` that is made up of parts e.g.`CommandBox`, `ResultDisplay`, `PersonListPanel`, `StatusBarFooter` etc. All these, including the `MainWindow`, inherit from the abstract `UiPart` class which captures the commonalities between classes that represent parts of the visible GUI.
 
-The `UI` component uses the JavaFx UI framework. The layout of these UI parts are defined in matching `.fxml` files that are in the `src/main/resources/view` folder. For example, the layout of the [`MainWindow`](https://github.com/se-edu/addressbook-level3/tree/master/src/main/java/seedu/address/ui/MainWindow.java) is specified in [`MainWindow.fxml`](https://github.com/se-edu/addressbook-level3/tree/master/src/main/resources/view/MainWindow.fxml)
+The `UI` component uses the JavaFX UI framework. The layout of these UI parts are defined in matching `.fxml` files that are in the `src/main/resources/view` folder. For example, the layout of the [`MainWindow`](https://github.com/se-edu/addressbook-level3/tree/master/src/main/java/seedu/address/ui/MainWindow.java) is specified in [`MainWindow.fxml`](https://github.com/se-edu/addressbook-level3/tree/master/src/main/resources/view/MainWindow.fxml)
 
 The `UI` component,
 
@@ -477,7 +477,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 ### Glossary
 
-* **Mainstream OS**: Windows, Linux, Unix, MacOS
+* **Mainstream OS**: Windows, Linux, Unix, macOS
 * **Private contact detail**: A contact detail that is not meant to be shared with others
 * **Tag**: A label attached to a student to help tutors categorize or filter students, such as `Math`, `Sec4`, or `ExamPrep`
 
@@ -492,7 +492,7 @@ testers are expected to do more *exploratory* testing.
 
 </div>
 
-### Launch and shutdown
+### Launch and shut down
 
 1. Initial launch
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -267,18 +267,18 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 **MSS**
 
 1. Tutor enters the command to add a student.
-2. OnlyTutors saves the changes and shows confirmation.
+2. OnlyTutors saves the student and informs the tutor of the successful addition.
 
     Use case ends.
 
 **Extensions**
 * 1a. OnlyTutors detects missing or invalid parameter
-  * 1a1. OnlyTutors shows an error message.
+  * 1a1. OnlyTutors informs the tutor of the error.
 
     Use case ends.
 
 * 1b. OnlyTutors detects a duplicate student (based on name and phone number)
-  * 1b1. OnlyTutors rejects the add and gives a warning.
+  * 1b1. OnlyTutors informs the tutor that the student already exists.
 
     Use case ends
 
@@ -291,13 +291,13 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 **MSS**
 1. Tutor enters the command to delete a student.
 2. OnlyTutors deletes the student at the specified index.
-3. OnlyTutors shows a confirmation message with the deleted student's information.
+3. OnlyTutors informs the tutor of the successful deletion.
 
     Use case ends.
 
 **Extensions**
 * 1a. OnlyTutors detects a missing, invalid or non-integer index
-  *  1a1. OnlyTutors shows an error message.
+  *  1a1. OnlyTutors informs the tutor of the error.
 
         Use case ends
 
@@ -305,25 +305,25 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 **Use case 03: List all students**
 
 **Guarantees**
-* Displays all students currently stored in the system, including all their details
+* All students currently stored in the system are shown, including all their details
 (name, phone, address, lesson day/time, tuition rate, payment status, tags).
-* If no students exist, displays an empty list message.
+* If no students exist, the tutor is informed that the list is empty.
 
 **MSS**
 1. Tutor enters the command to list all students.
 2. OnlyTutors retrieves all student contacts from the system.
-3. OnlyTutors displays the list of students with all relevant details.
+3. OnlyTutors presents the list of students with all relevant details.
 
     Use case ends.
 
 **Extensions**
 * 1a. OnlyTutors detects an unknown command or typo
-    * 1a1. OnlyTutors displays an error message.
+    * 1a1. OnlyTutors informs the tutor of the error.
 
         Use case ends.
 
 * 2a. OnlyTutors detects no existing student contacts in the system
-    * 2a1. OnlyTutors displays a notification message.
+    * 2a1. OnlyTutors informs the tutor that there are no students.
 
         Use case ends.
 
@@ -331,29 +331,28 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 **Use case 04: Tag a student**
 
 **Guarantees**
-* Tags are added to a student if and only if the `INDEX` parameter is valid, all `TAG` parameters are valid, and none of the specified tags already exist on that student.
+* Tags are added to a student if and only if the `INDEX` parameter is valid, all `TAG` parameters are valid, and at least one of the specified tags does not already exist on that student.
 
 **MSS**
 1. Tutor enters the command to tag a student.
-2. OnlyTutors adds the specified tag(s) to the student at the given index.
-3. OnlyTutors shows a confirmation message with the updated student's information.
+2. OnlyTutors adds the specified tag(s) to the student at the given index. Tags that already exist on the student are ignored.
+3. OnlyTutors informs the tutor of the successfully added tags.
 
     Use case ends.
 
 **Extensions**
 * 1a. OnlyTutors detects a missing, invalid or non-integer index
-  * 1a1. OnlyTutors shows an error message.
+  * 1a1. OnlyTutors informs the tutor of the error.
 
     Use case ends.
 
 * 1b. OnlyTutors detects a missing or invalid tag
-  * 1b1. OnlyTutors shows an error message.
+  * 1b1. OnlyTutors informs the tutor of the error.
 
     Use case ends.
 
-* 2a. OnlyTutors detects that one or more tags already exist on the student
-  * 2a1. OnlyTutors shows an error message.
-  * 2a2. No tags are added to the student.
+* 2a. OnlyTutors detects that all specified tags already exist on the student
+  * 2a1. OnlyTutors informs the tutor that no changes were made.
 
     Use case ends.
 
@@ -361,29 +360,28 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 **Use case 05: Delete tags from a student**
 
 **Guarantees**
-* Tags are removed from a student if and only if the `INDEX` parameter is valid and all specified `TAG` parameters exist for that student.
+* Tags are removed from a student if and only if the `INDEX` parameter is valid and at least one of the specified `TAG` parameters exists for that student.
 
 **MSS**
 1. Tutor enters the command to delete tags from a student.
-2. OnlyTutors removes the specified tag(s) from the student at the given index.
-3. OnlyTutors shows a confirmation message with the updated student's information.
+2. OnlyTutors removes the specified tag(s) that exist on the student. Tags that do not exist on the student are ignored.
+3. OnlyTutors informs the tutor of the successfully removed tags.
 
     Use case ends.
 
 **Extensions**
 * 1a. OnlyTutors detects a missing, invalid or non-integer index
-  * 1a1. OnlyTutors shows an error message.
+  * 1a1. OnlyTutors informs the tutor of the error.
 
     Use case ends.
 
 * 1b. OnlyTutors detects a missing or invalid tag
-  * 1b1. OnlyTutors shows an error message.
+  * 1b1. OnlyTutors informs the tutor of the error.
 
     Use case ends.
 
-* 2a. OnlyTutors detects that one or more specified tags do not exist on the student
-  * 2a1. OnlyTutors shows an error message.
-  * 2a2. No tags are deleted from the student.
+* 2a. OnlyTutors detects that none of the specified tags exist on the student
+  * 2a1. OnlyTutors informs the tutor that no changes were made.
 
     Use case ends.
 
@@ -396,18 +394,18 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 **MSS**
 1. Tutor enters the command to mark one or more students as paid.
 2. OnlyTutors updates the payment status of the specified student(s) to paid.
-3. OnlyTutors shows a confirmation message with the marked student(s).
+3. OnlyTutors informs the tutor of the successfully marked student(s).
 
     Use case ends.
 
 **Extensions**
 * 1a. OnlyTutors detects a missing, invalid or non-integer index
-  * 1a1. OnlyTutors shows an error message.
+  * 1a1. OnlyTutors informs the tutor of the error.
 
     Use case ends.
 
 * 2a. OnlyTutors detects that one or more students are already marked as paid
-  * 2a1. OnlyTutors shows an error message identifying the already-paid student(s).
+  * 2a1. OnlyTutors informs the tutor which student(s) are already paid.
   * 2a2. No students are marked.
 
     Use case ends.
@@ -421,18 +419,18 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 **MSS**
 1. Tutor enters the command to unmark one or more students as unpaid.
 2. OnlyTutors updates the payment status of the specified student(s) to unpaid.
-3. OnlyTutors shows a confirmation message with the unmarked student(s).
+3. OnlyTutors informs the tutor of the successfully unmarked student(s).
 
     Use case ends.
 
 **Extensions**
 * 1a. OnlyTutors detects a missing, invalid or non-integer index
-  * 1a1. OnlyTutors shows an error message.
+  * 1a1. OnlyTutors informs the tutor of the error.
 
     Use case ends.
 
 * 2a. OnlyTutors detects that one or more students are already marked as unpaid
-  * 2a1. OnlyTutors shows an error message identifying the already-unpaid student(s).
+  * 2a1. OnlyTutors informs the tutor which student(s) are already unpaid.
   * 2a2. No students are unmarked.
 
     Use case ends.
@@ -445,16 +443,16 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 **MSS**
 1. Tutor enters the `clear` command.
-2. OnlyTutors displays a confirmation prompt: `This will delete all contacts. Are you sure? [y/N]:`.
-3. Tutor enters `y`.
-4. OnlyTutors deletes all contacts and shows a success message.
+2. OnlyTutors asks the tutor to confirm the action.
+3. Tutor confirms.
+4. OnlyTutors deletes all students and informs the tutor of the successful clear.
 
     Use case ends.
 
 **Extensions**
-* 3a. Tutor enters `n` or any input other than `y`
-  * 3a1. OnlyTutors aborts the clear and shows an aborted message.
-  * 3a2. No contacts are deleted.
+* 3a. Tutor does not confirm (enters `n` or any input other than `y`)
+  * 3a1. OnlyTutors aborts the clear and informs the tutor.
+  * 3a2. No students are deleted.
 
     Use case ends.
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -32,7 +32,7 @@ Refer to the guide [_Setting up and getting started_](SettingUp.md).
 
 <div markdown="span" class="alert alert-primary">
 
-:bulb: **Tip:** The `.puml` files used to create diagrams are in this document `docs/diagrams` folder. Refer to the [_PlantUML Tutorial_ at se-edu/guides](https://se-education.org/guides/tutorials/plantUml.html) to learn how to create and edit diagrams.
+:bulb: **Tip:** The `.puml` files used to create diagrams are in the `docs/diagrams` folder.
 </div>
 
 ### Architecture
@@ -246,6 +246,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 | `* * *`  | miserly tutor            | record tuition rates and payment status                        | track my income properly                                        |
 | `* *`    | careless tutor           | undo my actions                                                | rectify my mistakes                                             |
 | `* *`    | humble tutor             | edit my student's information easily                           | correct any wrong or outdated contact info without hassle       |
+| `* *`    | tutor with many students | search for a student by name                                   | quickly locate a student without scrolling through the list     |
 | `* *`    | tutor with many students | filter students by tags                                        | quickly find a specific group of students                       |
 | `* *`    | tutor                    | export and import my data                                      | backup or switch devices                                        |
 | `*`      | analytical tutor         | view a summary of my monthly teaching hours and income         | evaluate my profile and workload                                |
@@ -478,7 +479,8 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 ### Glossary
 
 * **Mainstream OS**: Windows, Linux, Unix, macOS
-* **Private contact detail**: A contact detail that is not meant to be shared with others
+* **Parsing**: The process of analysing a user's text input and breaking it into structured components (e.g. command word, prefixes, arguments) that the application can understand and execute
+* **Subcommand**: A secondary keyword that follows a main command word to specify a particular action (e.g. `tag add`, `tag delete`, `tag find` are subcommands of `tag`)
 * **Tag**: A label attached to a student to help tutors categorize or filter students, such as `Math`, `Sec4`, or `ExamPrep`
 
 --------------------------------------------------------------------------------------------------------------------

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -202,7 +202,7 @@ Refer to the [Features](#features) section below for the full details of each co
 
 | Parameter | Prefix | Constraints                                                                                                         | Example |
 |-----------|--------|---------------------------------------------------------------------------------------------------------------------|---------|
-| **Name** | `n/` | Letters and spaces only; cannot be blank                                                                            | `n/John Doe` |
+| **Name** | `n/` | Letters, spaces, and `/` only (e.g. `S/O`); cannot be blank                                                        | `n/Raj S/O Kumar` |
 | **Phone** | `p/` | Exactly 8 digits, starting with 6, 8, or 9 (Singapore format)                                                       | `p/91234567` |
 | **Email** | `e/` | Standard email format (`local@domain`)                                                                              | `e/john@example.com` |
 | **Address** | `a/` | At least 3 characters long, must not be blank                                                                       | `a/Blk 30, Geylang St 29` |
@@ -223,6 +223,7 @@ Adds a new student to OnlyTutors.
 </div>
 
 * All fields are required.
+* Day names are case-insensitive (e.g. `monday`, `Monday`, `MONDAY` are all accepted).
 * Tags cannot be added during the `add` command. Use [`tag add`](#adding-tags-to-a-student-tag-add) after adding the student.
 * New students are marked as **Unpaid** by default.
 
@@ -330,9 +331,6 @@ Editing tags with the `edit` command **replaces all existing tags**. If a studen
 To add tags without replacing, use [`tag add`](#adding-tags-to-a-student-tag-add) instead.
 </div>
 
-<div markdown="block" class="alert alert-info">
-</div>
-
 **Examples:**
 
 | Command | What it does |
@@ -394,7 +392,7 @@ Finds students who match all of the given tags exactly.
 | Command                         | What it does                                                |
 |---------------------------------|-------------------------------------------------------------|
 | `tag find t/Math`               | Returns students tagged with `Math`                         |
-| `tag find t/Primary3 t/Science` | Returns students tagged with both `Primary 3` and `Science` |
+| `tag find t/Primary3 t/Science` | Returns students tagged with both `Primary3` and `Science` |
 | `tag find t/ma`                 | Returns no students unless a student has the exact tag `ma` |
 
 **Invalid input:**
@@ -535,7 +533,7 @@ You can mark multiple students as paid at once by specifying multiple indices. e
 | `find John` then `mark 1` | Marks the 1st student in the `find` results as paid |
 
 **Expected output** (on success):
-> `Marked 1 student(s) as paid: John Doe`
+> `Marked 1 student(s) as paid: (8) John Doe`
 
 --------------------------------------------------------------------------------------------------------------------
 
@@ -563,7 +561,7 @@ You can unmark multiple students at once by specifying multiple indices. e.g. `u
 | `unmark 1 2 3` | Marks the 1st, 2nd, and 3rd students as unpaid |
 
 **Expected output** (on success):
-> `Marked 3 student(s) as unpaid: John Doe, Jane Smith, Vincent`
+> `Marked 3 student(s) as unpaid: (8) John Doe, (9) Jane Smith, (10) Vincent`
 
 --------------------------------------------------------------------------------------------------------------------
 
@@ -594,6 +592,8 @@ Shows a message with a link to this User Guide.
 **Format:** `help`
 </div>
 
+* Any extra text after `help` is ignored (e.g. `help abc` is treated as `help`).
+
 ![help message](images/helpMessage.png)
 
 --------------------------------------------------------------------------------------------------------------------
@@ -605,6 +605,8 @@ Exits the program.
 <div markdown="span" class="alert alert-success">
 **Format:** `exit`
 </div>
+
+* Any extra text after `exit` is ignored (e.g. `exit abc` is treated as `exit`).
 
 --------------------------------------------------------------------------------------------------------------------
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -302,6 +302,8 @@ Shows a list of all students in OnlyTutors.
 Use `list` after a [`find`](#finding-students-by-name-find) command to return to the full student list.
 </div>
 
+* Any extra text after `list` is ignored (e.g. `list abc` is treated as `list`).
+
 **Expected output:**
 > `Listed all persons`
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -202,7 +202,7 @@ Refer to the [Features](#features) section below for the full details of each co
 
 | Parameter | Prefix | Constraints                                                                                                         | Example |
 |-----------|--------|---------------------------------------------------------------------------------------------------------------------|---------|
-| **Name** | `n/` | Letters, spaces, and `/` only (e.g. `S/O`); cannot be blank                                                        | `n/Raj S/O Kumar` |
+| **Name** | `n/` | English alphabets, spaces, and `/` only (e.g. `S/O`); cannot be blank                                              | `n/Raj S/O Kumar` |
 | **Phone** | `p/` | Exactly 8 digits, starting with 6, 8, or 9 (Singapore format)                                                       | `p/91234567` |
 | **Email** | `e/` | Standard email format (`local@domain`)                                                                              | `e/john@example.com` |
 | **Address** | `a/` | At least 3 characters long, must not be blank                                                                       | `a/Blk 30, Geylang St 29` |
@@ -224,6 +224,7 @@ Adds a new student to OnlyTutors.
 
 * All fields are required.
 * Day names are case-insensitive (e.g. `monday`, `Monday`, `MONDAY` are all accepted).
+* Each student can only have **one lesson schedule** (one day and time). Support for multiple lessons is planned for a future version.
 * Tags cannot be added during the `add` command. Use [`tag add`](#adding-tags-to-a-student-tag-add) after adding the student.
 * New students are marked as **Unpaid** by default.
 
@@ -452,6 +453,7 @@ Adds one or more tags to a student **without replacing** existing tags.
 * The index **must be a positive integer** (1, 2, 3, …).
 * At least one tag must be provided.
 * Tags can contain any characters but must not be empty and cannot have more than 20 characters.
+* Tags are **case-insensitive** — `Math`, `math`, and `MATH` are treated as the same tag. The display preserves the casing of the first version added.
 * The command updates every selected student who is missing at least one of the specified tags.
 * The command fails only if it would not change any selected student.
 
@@ -516,7 +518,7 @@ Marks a student's payment status as **Paid**.
 
 * Marks the student(s) at the specified `INDEX`(es) as paid.
 * The index **must be a positive integer** (1, 2, 3, …).
-* If any student is already marked as paid, the command will fail with: `This student has already been marked as paid.`
+* If **any** student in the batch is already marked as paid, the **entire command will fail** and no students will be marked. Ensure all specified students are currently unpaid before running the command.
 
 The payment status is displayed on each student's card as a **Paid** or **Unpaid** label next to the rate.
 
@@ -533,7 +535,7 @@ You can mark multiple students as paid at once by specifying multiple indices. e
 | `find John` then `mark 1` | Marks the 1st student in the `find` results as paid |
 
 **Expected output** (on success):
-> `Marked 1 student(s) as paid: (8) John Doe`
+> `Marked 1 student(s) as paid: (1) John Doe`
 
 --------------------------------------------------------------------------------------------------------------------
 
@@ -547,7 +549,7 @@ Marks a student's payment status as **Unpaid**.
 
 * Marks the student(s) at the specified `INDEX`(es) as unpaid.
 * The index **must be a positive integer** (1, 2, 3, …).
-* If any student is already marked as unpaid, the command will fail with: `This student has already been marked as unpaid.`
+* If **any** student in the batch is already marked as unpaid, the **entire command will fail** and no students will be unmarked. Ensure all specified students are currently paid before running the command.
 
 <div markdown="span" class="alert alert-primary">:bulb: **Tip:**
 You can unmark multiple students at once by specifying multiple indices. e.g. `unmark 1 2 3` marks the 1st, 2nd, and 3rd students as unpaid. Use this at the start of a new payment cycle to reset payment statuses. See also: [`mark`](#marking-a-student-as-paid-mark).
@@ -561,7 +563,7 @@ You can unmark multiple students at once by specifying multiple indices. e.g. `u
 | `unmark 1 2 3` | Marks the 1st, 2nd, and 3rd students as unpaid |
 
 **Expected output** (on success):
-> `Marked 3 student(s) as unpaid: (8) John Doe, (9) Jane Smith, (10) Vincent`
+> `Marked 3 student(s) as unpaid: (1) John Doe, (2) Jane Smith, (3) Vincent`
 
 --------------------------------------------------------------------------------------------------------------------
 
@@ -658,7 +660,10 @@ If your changes to the data file make its format invalid, OnlyTutors may discard
 |------|---------|
 | **CLI** | Command Line Interface — a text-based way to interact with the app by typing commands |
 | **GUI** | Graphical User Interface — the visual window you see when running the app |
-| **Index** | The number shown beside each student in the displayed list (e.g., 1, 2, 3) |
-| **Tag** | A label you can attach to a student for categorisation (e.g., `math`, `primary3`) |
-| **JSON** | A data file format used by OnlyTutors to store your student data |
 | **Home folder** | The folder where you placed the OnlyTutors `.jar` file; data is saved here |
+| **Index** | The number shown beside each student in the displayed list (e.g., 1, 2, 3) |
+| **JavaFX** | A Java library used to build the graphical interface of OnlyTutors |
+| **JDK** | Java Development Kit — the software needed to run Java applications like OnlyTutors |
+| **JSON** | A data file format used by OnlyTutors to store your student data |
+| **PATH** | An environment variable that tells your operating system where to find programs (e.g., `java`) |
+| **Tag** | A label you can attach to a student for categorisation (e.g., `math`, `primary3`) |


### PR DESCRIPTION
  - Fix JavaFx to JavaFX in DG (#272)                                          
  - Fix MacOS to macOS in DG (#273)
  - Fix shutdown to shut down in DG heading (#278)                           
  - Add case-insensitive note for Day in UG (#294)  
  - Remove stray blank block in UG edit section (#298)
  - Fix Primary 3 to Primary3 in tag find example (#308)
  - Fix mark/unmark expected output to include indices (#283, #284)
  - Document help/exit ignoring extra text (#289, #290)
  - Update Name constraints to use English alphabets and mention / in UG (#270)
  - Remove PlantUML tutorial link from DG (#293)
  - Add find user story to DG (#303)
  - Remove unused glossary term, add Parsing and Subcommand to DG (#310, #317)
  - Add JavaFX, JDK, PATH to UG glossary (#313)
  - Document single-lesson limitation in UG add command (#285)
  - Document mark/unmark all-or-nothing batch behavior (#288)
  - Document tag case-insensitive behavior (#291) 
  - Fix tag add use case to match actual behavior: ignore existing tags instead of failing (#304)
  - Fix tag delete use case to match actual behavior: ignore missing tags instead of failing (#297)
  - Replace UI-specific language (displays/shows) with abstract phrasing (informs the tutor) in all use cases (#306)

Closes #270, Closes #272, Closes #273, Closes #278, Closes #283, Closes    #284, Closes #285, Closes #288, Closes #289, Closes #290, Closes #291, Closes #293, Closes #294, Closes #297, Closes #298, Closes #303, Closes #304, Closes #306, Closes #308, Closes #310, Closes #313, Closes #317