### PR TITLE
Remove rationale for duplication detection from User Guide

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -233,25 +233,6 @@ OnlyTutors does not allow duplicate students. Two students are considered duplic
 (case-insensitive) **and** the **same phone number**.
 </div>
 
-<div markdown="block" class="alert alert-info">
-
-**:information_source: Rationale for duplicate detection:**
-
-OnlyTutors considers two contacts duplicates if they have the **same name (case-insensitive)** and **same phone number**.
-
-This design is chosen because:
-
-* Names alone are not unique (e.g. many students may share the same name)
-* Phone numbers alone are not reliable (e.g. siblings may share a parent’s number)
-* Combining both provides a practical and reliable identifier for tutors
-
-**Additionally:**
-
-* Duplicate detection is case-insensitive (e.g. `john doe` = `John Doe`)
-* Names are displayed exactly as entered to preserve user formatting
-
-</div>
-
 **Examples:**
 
 | Command | What it does |


### PR DESCRIPTION
## Summary
- Removes the "Rationale for duplicate detection" info block from the `add` command section in the User Guide
- The warning about duplicate detection behaviour is retained; only the internal design rationale is removed

Closes #253

## Test plan
- [ ] Review the `add` command section in the User Guide to confirm the rationale block is gone and surrounding content still reads correctly