### PR TITLE
Warn and default isPaid to false when field is missing in JSON

### DIFF
--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -4,11 +4,13 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Day;
@@ -26,6 +28,7 @@ import seedu.address.model.tag.Tag;
 class JsonAdaptedPerson {
 
     public static final String MISSING_FIELD_MESSAGE_FORMAT = "Person's %s field is missing!";
+    private static final Logger logger = LogsCenter.getLogger(JsonAdaptedPerson.class);
 
     private final String name;
     private final String phone;
@@ -35,7 +38,7 @@ class JsonAdaptedPerson {
     private final String startTime;
     private final String endTime;
     private final String rate;
-    private final boolean isPaid;
+    private final Boolean isPaid;
     private final List<JsonAdaptedTag> tags = new ArrayList<>();
 
     /**
@@ -46,7 +49,7 @@ class JsonAdaptedPerson {
                              @JsonProperty("email") String email, @JsonProperty("address") String address,
                              @JsonProperty("day") String day, @JsonProperty("startTime") String startTime,
                              @JsonProperty("endTime") String endTime, @JsonProperty("rate") String rate,
-                             @JsonProperty("isPaid") boolean isPaid,
+                             @JsonProperty("isPaid") Boolean isPaid,
                              @JsonProperty("tags") List<JsonAdaptedTag> tags) {
         this.name = name;
         this.phone = phone;
@@ -155,9 +158,17 @@ class JsonAdaptedPerson {
         }
         final Rate modelRate = new Rate(rate);
 
+        final boolean modelIsPaid;
+        if (isPaid == null) {
+            logger.warning("isPaid field is missing for person: " + name + ". Defaulting to Unpaid.");
+            modelIsPaid = false;
+        } else {
+            modelIsPaid = isPaid;
+        }
+
         final Set<Tag> modelTags = new HashSet<>(personTags);
         return new Person(modelName, modelPhone, modelEmail, modelAddress,
-                modelDay, modelStartTime, modelEndTime, modelRate, isPaid, modelTags);
+                modelDay, modelStartTime, modelEndTime, modelRate, modelIsPaid, modelTags);
     }
 
 }


### PR DESCRIPTION
## Summary
- Changed `isPaid` field in `JsonAdaptedPerson` from primitive `boolean` to `Boolean` (wrapper type) so Jackson surfaces a `null` instead of silently defaulting to `false`
- Added a null check in `toModelType()`: if `isPaid` is missing, a warning is logged identifying the affected student and the field defaults to `false` (Unpaid)
- No change to normal loading behaviour when the field is present

Closes #319

## Test plan
- [ ] Set `isPaid` to `null` in `data/onlytutors.json` for a student, relaunch the app — student loads as Unpaid and a warning appears in the log file
- [ ] Normal data file loads without any change in behaviour