### PR TITLE
Add hyperlinks throughout User Guide

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -7,7 +7,14 @@ title: User Guide
 
 While most apps rely on slow "point-and-click" menus, OnlyTutors is a Command-Line-First application. It is designed for those who want the efficiency of a terminal-based workflow without sacrificing the visual clarity of a modern dashboard. This design prioritises clear and consistent command syntax to ensure reliable input handling.
 
-OnlyTutors helps you manage your tutoring business more effectively than traditional apps by allowing you to maintain various data not seen in traditional apps.
+OnlyTutors helps you manage your tutoring business more effectively than traditional apps. Here is what you can do:
+
+* **Track student details** — store each student's name, phone number, email and address in one place.
+* **Schedule lessons** — record the day and time of each student's weekly lesson.
+* **Set tuition rates** — keep track of the hourly rate for each student.
+* **Monitor payment status** — mark students as Paid or Unpaid to stay on top of collections.
+* **Organise with tags** — label students by subject, level, or any category that suits you (e.g. `Math`, `Primary 3`).
+* **Search and filter** — find students quickly by name or tag.
 
 **Who is this guide for?** Private tutors who are comfortable typing commands and want a fast, no-frills way to keep track of their students.
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -14,7 +14,7 @@ OnlyTutors helps you manage your tutoring business more effectively than traditi
 * **Set tuition rates** — keep track of the hourly rate for each student.
 * **Monitor payment status** — mark students as Paid or Unpaid to stay on top of collections.
 * **Organise with tags** — label students by subject, level, or any category that suits you (e.g. `Math`, `Primary 3`).
-* **Search and filter** — find students quickly by name or tag.
+* **Search and filter** — find students quickly by [name](#finding-students-by-name-find) or [tag](#finding-students-by-tag-tag-find).
 
 **Who is this guide for?** Private tutors who are comfortable typing commands and want a fast, no-frills way to keep track of their students.
 
@@ -627,7 +627,7 @@ If your changes to the data file make its format invalid, OnlyTutors may discard
 **A**: Install OnlyTutors on the other computer and overwrite the empty data file it creates with the file that contains the data from your previous OnlyTutors home folder.
 
 **Q**: Can I add tags when adding a new student?<br>
-**A**: Yes. You can add tags immediately by appending the `t/` prefix to your `add` command (e.g., `... r/50 t/Math`).
+**A**: Yes. You can add tags immediately by appending the `t/` prefix to your [`add`](#adding-a-student-add) command (e.g., `... r/50 t/Math`).
 
 **Q**: How do I change a student's lesson day or time?<br>
 **A**: Use the [`edit`](#editing-a-student-edit) command. For example, `edit 1 d/Tuesday st/10:00 et/12:00` changes the 1st student's lesson to Tuesday, 10:00–12:00.


### PR DESCRIPTION
Resolves #249

## Summary
- Linked "name" and "tag" in the intro feature bullet to their respective find command sections
- Linked the `add` command reference in the FAQ to its section